### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,17 +128,21 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @items.present? %>
-      <%# if @items.image.attached? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "item_path(item.id)" do %>
+            <%= link_to "item_path(params[:id])" do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 
                 <%# 商品が売れていればsold outの表示 %>
-                <%# <div class='sold-out'>
+
+                <%# 購入の際に、購入者のID(current_user.id)が商品に登録されるように設定する前提,  (order_id: current_user.id)
+                
+                <%# if item.order_id.present? %>
+                <div class='sold-out'>
                   <span>Sold Out!!</span>
-                </div> %>
+                </div>
+                <%# end %>
                 <%# //商品が売れていればsold outの表示 %>
 
               </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:index, :new, :create]
+  resources :items
   # get 'items', to: 'items#calculate'
 end


### PR DESCRIPTION
#### what
- 出品した商品の一覧表示を実装
- 売却済みの商品をsold outに（購入機能の実装を想定）
#### why
- 出品した商品が見れるようにするため

###商品一覧画像
- https://i.gyazo.com/35fbca545b9e1386cbbf0ef293299d19.png